### PR TITLE
Ignore null and undefined

### DIFF
--- a/jsontoxml.js
+++ b/jsontoxml.js
@@ -195,6 +195,9 @@ function strReplaceChar(str, i, c, x) {
 }
 
 function esc(s, escapeUnicode){
+    if (s === null || s === undefined){
+      return str
+    }
     var str = s.toString();
     for(var i = 0; i < str.length; i++) {
 	var c = str.charCodeAt(i);


### PR DESCRIPTION
Ignores `null` and `undefined` and returns `value` and skips toString() conversion.